### PR TITLE
feat: necessary features for hcloud-cloud-controller-manager

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "ssh_public_key_filename" {
   description = "Path to the public SSH Key"
   value       = local_sensitive_file.ssh_public.filename
 }
+
+output "control_server_ipv4" {
+  description = "Public IPv4 of the control node"
+  value       = hcloud_server.control.ipv4_address
+}

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,16 @@ variable "name" {
   default     = "dev"
 }
 
+variable "deploy_hccm" {
+  description = "Deploy hcloud-cloud-controller-manager through Helm"
+  type        = bool
+  default     = true
+}
+variable "use_cloud_routes" {
+  description = "Use the Hetzner Cloud network routes for Pod traffic. Enables hcloud-cloud-controller-manager routes controller and Cilium native routing. Does not work with Robot servers."
+  type        = bool
+  default     = true
+}
 variable "worker_count" {
   description = "Number of worker for the environment"
   type        = number


### PR DESCRIPTION
- Variable to disable HCCM: We want to deploy this from the local sources
- Variable to disable cloud routes: Does not work with Robot servers,
  which we use in one test suite
- Output for the control-plane server: Used to join the Robot server
- `ENV_NAME` in `env.sh`: Used in HCCM tests to find resources in the
  Cloud API

HCCM also requires the following other PRs to be merged. These are all stacked onto eachother:
- #15 
- #16 
- #17 