### PR TITLE
feat: allow setting HCLOUD_ENDPOINT env for hccm

### DIFF
--- a/main-setup.tf
+++ b/main-setup.tf
@@ -180,6 +180,11 @@ resource "helm_release" "hcloud_cloud_controller_manager" {
     value = tostring(var.use_cloud_routes)
     type  = "string"
   }
+
+  set {
+    name  = "env.HCLOUD_ENDPOINT.value"
+    value = var.hcloud_endpoint
+  }
 }
 
 resource "helm_release" "hcloud_csi_driver" {

--- a/main-setup.tf
+++ b/main-setup.tf
@@ -183,7 +183,7 @@ resource "helm_release" "hcloud_cloud_controller_manager" {
 
   set {
     name  = "env.HCLOUD_ENDPOINT.value"
-    value = var.hcloud_endpoint
+    value = var.hccm_hcloud_endpoint
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,11 @@ variable "hcloud_labels" {
   type        = map(string)
   default     = {}
 }
+variable "hcloud_endpoint" {
+  description = "Sets the HCLOUD_ENDPOINT environment variable in the hcloud-cloud-controller-manager helm chart"
+  type        = string
+  default     = "https://api.hetzner.cloud/v1"
+}
 
 # K3S
 variable "k3s_channel" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,9 @@ variable "hcloud_labels" {
   type        = map(string)
   default     = {}
 }
-variable "hcloud_endpoint" {
+
+# hcloud-cloud-controller-manager
+variable "hccm_hcloud_endpoint" {
   description = "Sets the HCLOUD_ENDPOINT environment variable in the hcloud-cloud-controller-manager helm chart"
   type        = string
   default     = "https://api.hetzner.cloud/v1"


### PR DESCRIPTION
Allow setting the HCLOUD_ENDPOINT environment variable via Terraform variables for the hcloud-cloud-controller-manager.