### PR TITLE
fix: k3sup breaking changes

### DIFF
--- a/main-setup.tf
+++ b/main-setup.tf
@@ -31,7 +31,7 @@ resource "terraform_data" "k3sup_control" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      k3sup install --print-config=false \
+      k3sup install \
         --ssh-key='${local_sensitive_file.ssh_private.filename}' \
         --ip='${hcloud_server.control.ipv4_address}' \
         --k3s-channel='${var.k3s_channel}' \


### PR DESCRIPTION
k3sup [removed a flag](https://github.com/alexellis/k3sup/compare/0.13.9...0.13.10#diff-cfcd5a78ad9476ee24d7680dd023e71136f329c771d76ae6837ba68320b6379cL161-L165) in its latest release, which causes our CIs to break. This happens, because we currently do not pin the k3sup version during installation.

We previously disabled printing the config file, but this whole feature got removed, so we can safely remove the flag.