### PR TITLE
docs: fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@
 
 - k3sup breaking changes (#117)
 
-## [v0.9.1](https://github.com/hetznercloud/kubernetes-dev-env/releases/tag/v0.9.1)
-
-### Bug Fixes
-
-- k3sup breaking changes (#117)
-
 ## [v0.9.0](https://github.com/hetznercloud/kubernetes-dev-env/releases/tag/v0.9.0)
 
 ### Features


### PR DESCRIPTION
releaser-pleaser had a permission issue and could not create the tag ([job logs](https://github.com/hetznercloud/kubernetes-dev-env/actions/runs/16018250993/job/45189031210#step:3:36)). This changelog was updated but no tag and release were created. 